### PR TITLE
Fixed two bugs in CoreMotion.yml

### DIFF
--- a/apidoc/CoreMotion.yml
+++ b/apidoc/CoreMotion.yml
@@ -13,7 +13,7 @@ description: |
     magnetometer. The Core Motion module allows you to access the metrics provided by these sensors.
 
     For instruction and examples of using the Core Motion Module, see the
-    [Core Motion Module guide](http://docs.appcelerator.com/titanium/latest/#!/guide/Core_Motion_Module).
+    [Core Motion Module guide](http://docs.appcelerator.com/platform/latest/#!/guide/Core_Motion_Module).
 
     ### Requirements
 
@@ -577,7 +577,7 @@ properties:
 ---
 name: CoreMotionStepCountingQueryDataWithSuccess
 summary: |
-    Dictionary passed to the callback of the [StepCounter.ueryStepCount()](Modules.CoreMotion.StepCounter.queryStepCount) method.
+    Dictionary passed to the callback of the [StepCounter.queryStepCount()](Modules.CoreMotion.StepCounter.queryStepCount) method.
 platforms: [iphone, ipad]
 since: "3.3.0"
 extends: CoreMotionStepCountingQueryData


### PR DESCRIPTION
As mentioned in https://jira.appcelerator.org/browse/TIDOC-3091, I fixed two issues with this yaml file: broken link to Core Motion Module guide and fixed a typo.